### PR TITLE
Update to .NET 6 and WinAppSDK 1.0.3

### DIFF
--- a/WinUI_UnitTestTemplates/source.extension.vsixmanifest
+++ b/WinUI_UnitTestTemplates/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="WinUIUnitTestTemplates" Version="0.1.1" Language="en-US" Publisher="Marcel Wagner" />
+        <Identity Id="WinUIUnitTestTemplates" Version="0.2.0" Language="en-US" Publisher="Marcel Wagner" />
         <DisplayName>WinUI Unit Test Templates</DisplayName>
         <Description xml:space="preserve">Experimental WinUI Unit test projects (with known issues).
 For a list of current limitations/known issues, visit: https://github.com/chingucoding/winui-unittest-templates</Description>

--- a/readme.md
+++ b/readme.md
@@ -10,7 +10,8 @@ You can download the extension from the [Visual Studio marketplace](https://mark
 * Test runs may occasionally fail with an error of "The active test run was aborted. Reason: Unable to communicate with test host process."
 	* Rebuilding the project or reopening the solution will often fixes this issue.
 * Debugger with VS 2019 does not register correctly that test run has completed; VS stays in debugging mode.
-* VS Test discovery "leaks" two window when running tests, i.e. the templates that host UI will leave a window open when started through the test runner and running the tests will also leave the app open.
+* > *VS Test discovery "leaks" two window when running tests, i.e. the templates that host UI will leave a window open when started through the test runner and running the tests will also leave the app open.*
+* This was a problem with WinAppSDK 1.0.0 but does not seem to be present with the latest version of Visual Studio 2022 and WinAppSDK 1.0.3
 
 #### Building
 1. Run the  `./CopyTemplatesToExtension.ps1` script to copy the templates to the extension.

--- a/templates/WinUI Unit Tests no UI/UnitTestApp.csproj
+++ b/templates/WinUI Unit Tests no UI/UnitTestApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+		<TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>$safeprojectname$</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.3" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
 		<PackageReference Include="MSTest.TestAdapter">
 			<Version>2.2.8</Version>

--- a/templates/WinUI Unit Tests with UI/UnitTestApp.csproj
+++ b/templates/WinUI Unit Tests with UI/UnitTestApp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net5.0-windows10.0.19041.0</TargetFramework>
+		<TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>$safeprojectname$</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.0" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.0.3" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22000.194" />
 		<PackageReference Include="MSTest.TestAdapter">
 			<Version>2.2.8</Version>


### PR DESCRIPTION
This PR updates the templates to .NET 6 and WinAppSDK 1.0.3. Closes #2